### PR TITLE
Add nix install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ temporarily.
 
 Arch users can install [edir from the AUR](https://aur.archlinux.org/packages/edir/).
 
+Nix users can install [edir from the nixpkgs collection](https://search.nixos.org/packages?query=edir).
+
 Python 3.6 or later is required. Note [edir is on
 PyPI](https://pypi.org/project/edir/) so just ensure that
 `python3-pip` and `python3-wheel` are installed then type the following


### PR DESCRIPTION
Hi,

I am using `edir` on NixOS, and the package is now available on the newly released `21.05` version of NixOS. Proposing here to add installation instructions for NixOS, as well as it has been done for arch.

And thank you for having made `edir`. :ok_hand: