### PR TITLE
Reset output color in the terminal after the log function

### DIFF
--- a/edir.py
+++ b/edir.py
@@ -53,7 +53,7 @@ def log(func, msg, *, error=False):
         if args.no_color:
             print(msg, file=out)
         else:
-            print(COLORS[func] + msg, file=out)
+            print(COLORS[func] + msg + '\033[0m', file=out)
 
 def run(cmd):
     'Run given command and return stdout, stderr'


### PR DESCRIPTION
Currently the log function colors output by issuing a color sequence (like `'\033[33m'`) before the actual message. This color persists in the terminal after edir quits. This change proposes to reset the color after each message.